### PR TITLE
chore: improved compression tests

### DIFF
--- a/zstd_compression/test_helpers/compression_test_helpers.go
+++ b/zstd_compression/test_helpers/compression_test_helpers.go
@@ -13,7 +13,6 @@ import (
 // ZstdTestCompressorFactory is a wrapper around the ZstdCompressorFactory that allows us to test the
 // zstd compression middleware more thoroughly to confirm compression is working as expected.
 type ZstdTestCompressorFactory struct {
-	testHelper              zstdTestCompressor
 	CompressedDataChannel   chan int // receive data size in bytes
 	DecompressedDataChannel chan int // receive data size in bytes
 }
@@ -26,10 +25,6 @@ func (f ZstdTestCompressorFactory) NewCompressionStrategy(props compression.Comp
 		DecompressedDataChannel: f.DecompressedDataChannel,
 	}
 	return compressionStrategy
-}
-
-func (f ZstdTestCompressorFactory) GetTestHelper() zstdTestCompressor {
-	return f.testHelper
 }
 
 type zstdTestCompressor struct {

--- a/zstd_compression/test_helpers/compression_test_helpers.go
+++ b/zstd_compression/test_helpers/compression_test_helpers.go
@@ -1,0 +1,91 @@
+package test_helpers
+
+import (
+	"fmt"
+
+	"github.com/momentohq/client-sdk-go-compression-zstd/zstd_compression"
+	"github.com/momentohq/client-sdk-go/config/compression"
+	"github.com/momentohq/client-sdk-go/config/logger"
+	"github.com/momentohq/client-sdk-go/config/middleware"
+	impl "github.com/momentohq/client-sdk-go/config/middleware/impl"
+)
+
+// ZstdTestCompressorFactory is a wrapper around the ZstdCompressorFactory that allows us to test the
+// zstd compression middleware more thoroughly to confirm compression is working as expected.
+type ZstdTestCompressorFactory struct {
+	testHelper              zstdTestCompressor
+	CompressedDataChannel   chan int // receive data size in bytes
+	DecompressedDataChannel chan int // receive data size in bytes
+}
+
+func (f ZstdTestCompressorFactory) NewCompressionStrategy(props compression.CompressionStrategyProps) compression.CompressionStrategy {
+	compressionStrategy := zstdTestCompressor{
+		compressor:              zstd_compression.ZstdCompressorFactory{}.NewCompressionStrategy(props),
+		logger:                  props.Logger,
+		CompressedDataChannel:   f.CompressedDataChannel,
+		DecompressedDataChannel: f.DecompressedDataChannel,
+	}
+	return compressionStrategy
+}
+
+func (f ZstdTestCompressorFactory) GetTestHelper() zstdTestCompressor {
+	return f.testHelper
+}
+
+type zstdTestCompressor struct {
+	compressor              compression.CompressionStrategy
+	logger                  logger.MomentoLogger
+	CompressedDataChannel   chan int // receive data size in bytes
+	DecompressedDataChannel chan int // receive data size in bytes
+}
+
+func (h zstdTestCompressor) Compress(data []byte) ([]byte, error) {
+	compressed, err := h.compressor.Compress(data)
+	if err != nil {
+		return nil, fmt.Errorf("failed to compress data: %v", err)
+	}
+
+	h.logger.Trace("Compressed data: %d bytes -> %d bytes", len(data), len(compressed))
+	if h.CompressedDataChannel != nil {
+		h.CompressedDataChannel <- len(compressed)
+	}
+	return compressed, nil
+}
+
+func (h zstdTestCompressor) Decompress(data []byte) ([]byte, error) {
+	decompressed, err := h.compressor.Decompress(data)
+	if err != nil {
+		return nil, fmt.Errorf("failed to decompress data: %v", err)
+	}
+
+	h.logger.Trace("Decompressed data: %d bytes -> %d bytes", len(data), len(decompressed))
+	if h.DecompressedDataChannel != nil {
+		h.DecompressedDataChannel <- len(decompressed)
+	}
+	return decompressed, nil
+}
+
+type ZstdCompressionTestMiddlewareProps struct {
+	IncludeTypes            []interface{}
+	CompressionLevel        compression.CompressionLevel
+	Logger                  logger.MomentoLogger
+	CompressedDataChannel   chan int // receive data size in bytes
+	DecompressedDataChannel chan int // receive data size in bytes
+}
+
+// NewZstdCompressionTestMiddleware creates a new compression middleware as a test helper
+// for verifying compression is working as expected.
+func NewZstdCompressionTestMiddleware(props ZstdCompressionTestMiddlewareProps) middleware.Middleware {
+	compressionMiddlewareProps := impl.CompressionMiddlewareProps{
+		CompressorFactory: ZstdTestCompressorFactory{
+			CompressedDataChannel:   props.CompressedDataChannel,
+			DecompressedDataChannel: props.DecompressedDataChannel,
+		},
+		CompressionStrategyProps: compression.CompressionStrategyProps{
+			CompressionLevel: props.CompressionLevel,
+			Logger:           props.Logger,
+		},
+		IncludeTypes: props.IncludeTypes,
+	}
+	return impl.NewCompressionMiddleware(compressionMiddlewareProps)
+}

--- a/zstd_compression/zstd_compression_test.go
+++ b/zstd_compression/zstd_compression_test.go
@@ -7,13 +7,12 @@ import (
 	"time"
 
 	"github.com/google/uuid"
-	"github.com/momentohq/client-sdk-go-compression-zstd/zstd_compression"
+	"github.com/momentohq/client-sdk-go-compression-zstd/zstd_compression/test_helpers"
 	"github.com/momentohq/client-sdk-go/auth"
 	"github.com/momentohq/client-sdk-go/config"
 
 	"github.com/momentohq/client-sdk-go/config/compression"
 	"github.com/momentohq/client-sdk-go/config/logger/momento_default_logger"
-	"github.com/momentohq/client-sdk-go/config/middleware"
 	. "github.com/momentohq/client-sdk-go/momento"
 	"github.com/momentohq/client-sdk-go/responses"
 	. "github.com/onsi/ginkgo/v2"
@@ -70,16 +69,18 @@ var _ = Describe("zstd-compression-middleware", Label("cache-service"), func() {
 	// and no IncludeTypes are specified to narrow down the types of requests that should be compressed.
 	Describe("when IncludeTypes is not specified", func() {
 		It("should successfully set and get a value", func() {
-			createCacheClient(config.LaptopLatest().WithMiddleware([]middleware.Middleware{
-				zstd_compression.NewZstdCompressionMiddleware(zstd_compression.ZstdCompressionMiddlewareProps{
-					CompressionStrategyProps: compression.CompressionStrategyProps{
-						CompressionLevel: compression.CompressionLevelDefault,
-						Logger:           momento_default_logger.NewDefaultMomentoLoggerFactory(momento_default_logger.TRACE).GetLogger("zstd-test"),
-					},
-				}),
-			}))
+			compressedDataChannel := make(chan int, 1)
+			decompressedDataChannel := make(chan int, 1)
+			middleware := test_helpers.NewZstdCompressionTestMiddleware(test_helpers.ZstdCompressionTestMiddlewareProps{
+				CompressionLevel:        compression.CompressionLevelDefault,
+				Logger:                  momento_default_logger.NewDefaultMomentoLoggerFactory(momento_default_logger.TRACE).GetLogger("zstd-test"),
+				CompressedDataChannel:   compressedDataChannel,
+				DecompressedDataChannel: decompressedDataChannel,
+			})
+			createCacheClient(config.LaptopLatest().AddMiddleware(middleware))
 
 			value := getCompressableString()
+			originalSize := len(value)
 			_, err := cacheClient.Set(testCtx, &SetRequest{
 				CacheName: cacheName,
 				Key:       String("key"),
@@ -94,19 +95,30 @@ var _ = Describe("zstd-compression-middleware", Label("cache-service"), func() {
 			Expect(err).To(BeNil())
 			Expect(resp).To(BeAssignableToTypeOf(&responses.GetHit{}))
 			Expect(resp.(*responses.GetHit).ValueString()).To(Equal(value))
+
+			// Verify the channels received data
+			compressedSize, ok := <-compressedDataChannel
+			Expect(ok).To(BeTrue())
+			Expect(compressedSize).To(BeNumerically(">", 0))
+			Expect(compressedSize).To(BeNumerically("<", originalSize))
+			decompressedSize, ok := <-decompressedDataChannel
+			Expect(ok).To(BeTrue())
+			Expect(decompressedSize).To(Equal(originalSize))
 		})
 
 		It("should successfully setIf and get a value", func() {
-			createCacheClient(config.LaptopLatest().WithMiddleware([]middleware.Middleware{
-				zstd_compression.NewZstdCompressionMiddleware(zstd_compression.ZstdCompressionMiddlewareProps{
-					CompressionStrategyProps: compression.CompressionStrategyProps{
-						CompressionLevel: compression.CompressionLevelDefault,
-						Logger:           momento_default_logger.NewDefaultMomentoLoggerFactory(momento_default_logger.TRACE).GetLogger("zstd-test"),
-					},
-				}),
-			}))
+			compressedDataChannel := make(chan int, 1)
+			decompressedDataChannel := make(chan int, 1)
+			middleware := test_helpers.NewZstdCompressionTestMiddleware(test_helpers.ZstdCompressionTestMiddlewareProps{
+				CompressionLevel:        compression.CompressionLevelDefault,
+				Logger:                  momento_default_logger.NewDefaultMomentoLoggerFactory(momento_default_logger.TRACE).GetLogger("zstd-test"),
+				CompressedDataChannel:   compressedDataChannel,
+				DecompressedDataChannel: decompressedDataChannel,
+			})
+			createCacheClient(config.LaptopLatest().AddMiddleware(middleware))
 
 			setIfAbsentValue := getCompressableString()
+			originalSize := len(setIfAbsentValue)
 			_, err := cacheClient.SetIfAbsent(testCtx, &SetIfAbsentRequest{
 				CacheName: cacheName,
 				Key:       String("key"),
@@ -122,7 +134,17 @@ var _ = Describe("zstd-compression-middleware", Label("cache-service"), func() {
 			Expect(resp).To(BeAssignableToTypeOf(&responses.GetHit{}))
 			Expect(resp.(*responses.GetHit).ValueString()).To(Equal(setIfAbsentValue))
 
+			// Verify the channels received data
+			compressedSize, ok := <-compressedDataChannel
+			Expect(ok).To(BeTrue())
+			Expect(compressedSize).To(BeNumerically(">", 0))
+			Expect(compressedSize).To(BeNumerically("<", originalSize))
+			decompressedSize, ok := <-decompressedDataChannel
+			Expect(ok).To(BeTrue())
+			Expect(decompressedSize).To(Equal(originalSize))
+
 			setIfPresentValue := getCompressableString()
+			originalSize = len(setIfPresentValue)
 			_, err = cacheClient.SetIfPresentAndNotEqual(testCtx, &SetIfPresentAndNotEqualRequest{
 				CacheName: cacheName,
 				Key:       String("key"),
@@ -138,19 +160,30 @@ var _ = Describe("zstd-compression-middleware", Label("cache-service"), func() {
 			Expect(err).To(BeNil())
 			Expect(resp).To(BeAssignableToTypeOf(&responses.GetHit{}))
 			Expect(resp.(*responses.GetHit).ValueString()).To(Equal(setIfPresentValue))
+
+			// Verify the channels received data
+			compressedSize, ok = <-compressedDataChannel
+			Expect(ok).To(BeTrue())
+			Expect(compressedSize).To(BeNumerically(">", 0))
+			Expect(compressedSize).To(BeNumerically("<", originalSize))
+			decompressedSize, ok = <-decompressedDataChannel
+			Expect(ok).To(BeTrue())
+			Expect(decompressedSize).To(Equal(originalSize))
 		})
 
 		It("should successfully setWithHash and getWithHash", func() {
-			createCacheClient(config.LaptopLatest().WithMiddleware([]middleware.Middleware{
-				zstd_compression.NewZstdCompressionMiddleware(zstd_compression.ZstdCompressionMiddlewareProps{
-					CompressionStrategyProps: compression.CompressionStrategyProps{
-						CompressionLevel: compression.CompressionLevelDefault,
-						Logger:           momento_default_logger.NewDefaultMomentoLoggerFactory(momento_default_logger.TRACE).GetLogger("zstd-test"),
-					},
-				}),
-			}))
+			compressedDataChannel := make(chan int, 1)
+			decompressedDataChannel := make(chan int, 1)
+			middleware := test_helpers.NewZstdCompressionTestMiddleware(test_helpers.ZstdCompressionTestMiddlewareProps{
+				CompressionLevel:        compression.CompressionLevelDefault,
+				Logger:                  momento_default_logger.NewDefaultMomentoLoggerFactory(momento_default_logger.TRACE).GetLogger("zstd-test"),
+				CompressedDataChannel:   compressedDataChannel,
+				DecompressedDataChannel: decompressedDataChannel,
+			})
+			createCacheClient(config.LaptopLatest().AddMiddleware(middleware))
 
 			value := getCompressableString()
+			originalSize := len(value)
 			setResp, err := cacheClient.SetWithHash(testCtx, &SetWithHashRequest{
 				CacheName: cacheName,
 				Key:       String("key"),
@@ -169,19 +202,30 @@ var _ = Describe("zstd-compression-middleware", Label("cache-service"), func() {
 			Expect(resp).To(BeAssignableToTypeOf(&responses.GetWithHashHit{}))
 			Expect(resp.(*responses.GetWithHashHit).ValueString()).To(Equal(value))
 			Expect(resp.(*responses.GetWithHashHit).HashByte()).To(Equal(hash))
+
+			// Verify the channels received data
+			compressedSize, ok := <-compressedDataChannel
+			Expect(ok).To(BeTrue())
+			Expect(compressedSize).To(BeNumerically(">", 0))
+			Expect(compressedSize).To(BeNumerically("<", originalSize))
+			decompressedSize, ok := <-decompressedDataChannel
+			Expect(ok).To(BeTrue())
+			Expect(decompressedSize).To(Equal(originalSize))
 		})
 
 		It("should successfully setIfHash and getWithHash", func() {
-			createCacheClient(config.LaptopLatest().WithMiddleware([]middleware.Middleware{
-				zstd_compression.NewZstdCompressionMiddleware(zstd_compression.ZstdCompressionMiddlewareProps{
-					CompressionStrategyProps: compression.CompressionStrategyProps{
-						CompressionLevel: compression.CompressionLevelDefault,
-						Logger:           momento_default_logger.NewDefaultMomentoLoggerFactory(momento_default_logger.TRACE).GetLogger("zstd-test"),
-					},
-				}),
-			}))
+			compressedDataChannel := make(chan int, 1)
+			decompressedDataChannel := make(chan int, 1)
+			middleware := test_helpers.NewZstdCompressionTestMiddleware(test_helpers.ZstdCompressionTestMiddlewareProps{
+				CompressionLevel:        compression.CompressionLevelDefault,
+				Logger:                  momento_default_logger.NewDefaultMomentoLoggerFactory(momento_default_logger.TRACE).GetLogger("zstd-test"),
+				CompressedDataChannel:   compressedDataChannel,
+				DecompressedDataChannel: decompressedDataChannel,
+			})
+			createCacheClient(config.LaptopLatest().AddMiddleware(middleware))
 
 			setIfAbsentValue := getCompressableString()
+			originalSize := len(setIfAbsentValue)
 			setAbsentResp, err := cacheClient.SetIfAbsentOrHashEqual(testCtx, &SetIfAbsentOrHashEqualRequest{
 				CacheName: cacheName,
 				Key:       String("key"),
@@ -202,7 +246,17 @@ var _ = Describe("zstd-compression-middleware", Label("cache-service"), func() {
 			Expect(resp.(*responses.GetWithHashHit).ValueString()).To(Equal(setIfAbsentValue))
 			Expect(resp.(*responses.GetWithHashHit).HashByte()).To(Equal(hash))
 
+			// Verify the channels received data
+			compressedSize, ok := <-compressedDataChannel
+			Expect(ok).To(BeTrue())
+			Expect(compressedSize).To(BeNumerically(">", 0))
+			Expect(compressedSize).To(BeNumerically("<", originalSize))
+			decompressedSize, ok := <-decompressedDataChannel
+			Expect(ok).To(BeTrue())
+			Expect(decompressedSize).To(Equal(originalSize))
+
 			setIfPresentValue := getCompressableString()
+			originalSize = len(setIfPresentValue)
 			setPresentResp, err := cacheClient.SetIfPresentAndHashEqual(testCtx, &SetIfPresentAndHashEqualRequest{
 				CacheName: cacheName,
 				Key:       String("key"),
@@ -222,6 +276,15 @@ var _ = Describe("zstd-compression-middleware", Label("cache-service"), func() {
 			Expect(resp).To(BeAssignableToTypeOf(&responses.GetWithHashHit{}))
 			Expect(resp.(*responses.GetWithHashHit).ValueString()).To(Equal(setIfPresentValue))
 			Expect(resp.(*responses.GetWithHashHit).HashByte()).To(Equal(hash))
+
+			// Verify the channels received data
+			compressedSize, ok = <-compressedDataChannel
+			Expect(ok).To(BeTrue())
+			Expect(compressedSize).To(BeNumerically(">", 0))
+			Expect(compressedSize).To(BeNumerically("<", originalSize))
+			decompressedSize, ok = <-decompressedDataChannel
+			Expect(ok).To(BeTrue())
+			Expect(decompressedSize).To(Equal(originalSize))
 		})
 
 	})
@@ -230,18 +293,19 @@ var _ = Describe("zstd-compression-middleware", Label("cache-service"), func() {
 	// IncludeTypes is specified to narrow down the types of requests that should be compressed.
 	Describe("when IncludeTypes is specified", func() {
 		It("should successfully set and get a value without compression when not included", func() {
-			createCacheClient(config.LaptopLatest().WithMiddleware([]middleware.Middleware{
-				zstd_compression.NewZstdCompressionMiddleware(zstd_compression.ZstdCompressionMiddlewareProps{
-					CompressionStrategyProps: compression.CompressionStrategyProps{
-						CompressionLevel: compression.CompressionLevelDefault,
-						Logger:           momento_default_logger.NewDefaultMomentoLoggerFactory(momento_default_logger.TRACE).GetLogger("zstd-test"),
-					},
-					IncludeTypes: []interface{}{
-						SetWithHashRequest{},
-						GetWithHashRequest{},
-					},
-				}),
-			}))
+			compressedDataChannel := make(chan int, 1)
+			decompressedDataChannel := make(chan int, 1)
+			middleware := test_helpers.NewZstdCompressionTestMiddleware(test_helpers.ZstdCompressionTestMiddlewareProps{
+				CompressionLevel:        compression.CompressionLevelDefault,
+				Logger:                  momento_default_logger.NewDefaultMomentoLoggerFactory(momento_default_logger.TRACE).GetLogger("zstd-test"),
+				CompressedDataChannel:   compressedDataChannel,
+				DecompressedDataChannel: decompressedDataChannel,
+				IncludeTypes: []interface{}{
+					SetWithHashRequest{},
+					GetWithHashRequest{},
+				},
+			})
+			createCacheClient(config.LaptopLatest().AddMiddleware(middleware))
 
 			// Should not see Get or Set mentioned in compression logs
 
@@ -265,6 +329,7 @@ var _ = Describe("zstd-compression-middleware", Label("cache-service"), func() {
 			// Should see SetWithHash and GetWithHash mentioned in compression logs
 
 			hashKey := getCompressableString()
+			originalSize := len(value)
 			setResp, err := cacheClient.SetWithHash(testCtx, &SetWithHashRequest{
 				CacheName: cacheName,
 				Key:       String(hashKey),
@@ -283,20 +348,26 @@ var _ = Describe("zstd-compression-middleware", Label("cache-service"), func() {
 			Expect(getResp).To(BeAssignableToTypeOf(&responses.GetWithHashHit{}))
 			Expect(getResp.(*responses.GetWithHashHit).ValueString()).To(Equal(value))
 			Expect(getResp.(*responses.GetWithHashHit).HashByte()).To(Equal(hash))
+
+			// Verify the channels received data
+			compressedSize, ok := <-compressedDataChannel
+			Expect(ok).To(BeTrue())
+			Expect(compressedSize).To(BeNumerically(">", 0))
+			Expect(compressedSize).To(BeNumerically("<", originalSize))
+			decompressedSize, ok := <-decompressedDataChannel
+			Expect(ok).To(BeTrue())
+			Expect(decompressedSize).To(Equal(originalSize))
 		})
 
 		It("should not decompress when response was not compressed", func() {
-			createCacheClient(config.LaptopLatest().WithMiddleware([]middleware.Middleware{
-				zstd_compression.NewZstdCompressionMiddleware(zstd_compression.ZstdCompressionMiddlewareProps{
-					CompressionStrategyProps: compression.CompressionStrategyProps{
-						CompressionLevel: compression.CompressionLevelDefault,
-						Logger:           momento_default_logger.NewDefaultMomentoLoggerFactory(momento_default_logger.TRACE).GetLogger("zstd-test"),
-					},
-					IncludeTypes: []interface{}{
-						GetRequest{}, // try to decompress without any compression
-					},
-				}),
-			}))
+			middleware := test_helpers.NewZstdCompressionTestMiddleware(test_helpers.ZstdCompressionTestMiddlewareProps{
+				CompressionLevel: compression.CompressionLevelDefault,
+				Logger:           momento_default_logger.NewDefaultMomentoLoggerFactory(momento_default_logger.TRACE).GetLogger("zstd-test"),
+				IncludeTypes: []interface{}{
+					GetRequest{}, // try to decompress without any compression
+				},
+			})
+			createCacheClient(config.LaptopLatest().AddMiddleware(middleware))
 
 			value := "some-value"
 			_, err := cacheClient.Set(testCtx, &SetRequest{
@@ -320,32 +391,37 @@ var _ = Describe("zstd-compression-middleware", Label("cache-service"), func() {
 
 	Describe("when using json data", func() {
 		It("should successfully set and get and compress a json object", func() {
-			createCacheClient(config.LaptopLatest().WithMiddleware([]middleware.Middleware{
-				zstd_compression.NewZstdCompressionMiddleware(zstd_compression.ZstdCompressionMiddlewareProps{
-					CompressionStrategyProps: compression.CompressionStrategyProps{
-						CompressionLevel: compression.CompressionLevelDefault,
-						Logger:           momento_default_logger.NewDefaultMomentoLoggerFactory(momento_default_logger.TRACE).GetLogger("zstd-test"),
-					},
-				}),
-			}))
+			compressedDataChannel := make(chan int, 1)
+			decompressedDataChannel := make(chan int, 1)
+			middleware := test_helpers.NewZstdCompressionTestMiddleware(test_helpers.ZstdCompressionTestMiddlewareProps{
+				CompressionLevel:        compression.CompressionLevelDefault,
+				Logger:                  momento_default_logger.NewDefaultMomentoLoggerFactory(momento_default_logger.TRACE).GetLogger("zstd-test"),
+				CompressedDataChannel:   compressedDataChannel,
+				DecompressedDataChannel: decompressedDataChannel,
+			})
+			createCacheClient(config.LaptopLatest().AddMiddleware(middleware))
 
 			// User represents a sample JSON object
 			type User struct {
-				ID    int      `json:"id"`
-				Name  string   `json:"name"`
-				Email string   `json:"email"`
-				Tags  []string `json:"tags"`
+				ID          int      `json:"id"`
+				Name        string   `json:"name"`
+				Email       string   `json:"email"`
+				Tags        []string `json:"tags"`
+				Description string   `json:"description"`
 			}
 
 			sampleUser := User{
-				ID:    1,
-				Name:  "John Doe",
-				Email: "john.doe@example.com",
-				Tags:  []string{"tag1", "tag2"},
+				ID:          1,
+				Name:        "John Doe",
+				Email:       "john.doe@example.com",
+				Tags:        []string{"tag1", "tag2"},
+				Description: getCompressableString(),
 			}
 
 			sampleUserJSON, err := json.Marshal(sampleUser)
 			Expect(err).To(BeNil())
+
+			originalSize := len(sampleUserJSON)
 
 			_, err = cacheClient.Set(testCtx, &SetRequest{
 				CacheName: cacheName,
@@ -364,6 +440,15 @@ var _ = Describe("zstd-compression-middleware", Label("cache-service"), func() {
 			jsonErr := json.Unmarshal(resp.(*responses.GetHit).ValueByte(), &retrievedUser)
 			Expect(jsonErr).To(BeNil())
 			Expect(retrievedUser).To(Equal(sampleUser))
+
+			// Verify the channels received data
+			compressedSize, ok := <-compressedDataChannel
+			Expect(ok).To(BeTrue())
+			Expect(compressedSize).To(BeNumerically(">", 0))
+			Expect(compressedSize).To(BeNumerically("<", originalSize))
+			decompressedSize, ok := <-decompressedDataChannel
+			Expect(ok).To(BeTrue())
+			Expect(decompressedSize).To(Equal(originalSize))
 		})
 	})
 })

--- a/zstd_compression/zstd_compression_test.go
+++ b/zstd_compression/zstd_compression_test.go
@@ -54,6 +54,16 @@ func getCompressableString() string {
 	return fmt.Sprintf("%s %s", longString, uuid.NewString())
 }
 
+func verifyCompressionFromChannels(compressedDataChannel chan int, decompressedDataChannel chan int, originalSize int) {
+	compressedSize, ok := <-compressedDataChannel
+	Expect(ok).To(BeTrue())
+	Expect(compressedSize).To(BeNumerically(">", 0))
+	Expect(compressedSize).To(BeNumerically("<", originalSize))
+	decompressedSize, ok := <-decompressedDataChannel
+	Expect(ok).To(BeTrue())
+	Expect(decompressedSize).To(Equal(originalSize))
+}
+
 var _ = Describe("zstd-compression-middleware", Label("cache-service"), func() {
 	BeforeEach(func() {
 		testCtx = context.Background()
@@ -95,15 +105,7 @@ var _ = Describe("zstd-compression-middleware", Label("cache-service"), func() {
 			Expect(err).To(BeNil())
 			Expect(resp).To(BeAssignableToTypeOf(&responses.GetHit{}))
 			Expect(resp.(*responses.GetHit).ValueString()).To(Equal(value))
-
-			// Verify the channels received data
-			compressedSize, ok := <-compressedDataChannel
-			Expect(ok).To(BeTrue())
-			Expect(compressedSize).To(BeNumerically(">", 0))
-			Expect(compressedSize).To(BeNumerically("<", originalSize))
-			decompressedSize, ok := <-decompressedDataChannel
-			Expect(ok).To(BeTrue())
-			Expect(decompressedSize).To(Equal(originalSize))
+			verifyCompressionFromChannels(compressedDataChannel, decompressedDataChannel, originalSize)
 		})
 
 		It("should successfully setIf and get a value", func() {
@@ -133,15 +135,7 @@ var _ = Describe("zstd-compression-middleware", Label("cache-service"), func() {
 			Expect(err).To(BeNil())
 			Expect(resp).To(BeAssignableToTypeOf(&responses.GetHit{}))
 			Expect(resp.(*responses.GetHit).ValueString()).To(Equal(setIfAbsentValue))
-
-			// Verify the channels received data
-			compressedSize, ok := <-compressedDataChannel
-			Expect(ok).To(BeTrue())
-			Expect(compressedSize).To(BeNumerically(">", 0))
-			Expect(compressedSize).To(BeNumerically("<", originalSize))
-			decompressedSize, ok := <-decompressedDataChannel
-			Expect(ok).To(BeTrue())
-			Expect(decompressedSize).To(Equal(originalSize))
+			verifyCompressionFromChannels(compressedDataChannel, decompressedDataChannel, originalSize)
 
 			setIfPresentValue := getCompressableString()
 			originalSize = len(setIfPresentValue)
@@ -160,15 +154,7 @@ var _ = Describe("zstd-compression-middleware", Label("cache-service"), func() {
 			Expect(err).To(BeNil())
 			Expect(resp).To(BeAssignableToTypeOf(&responses.GetHit{}))
 			Expect(resp.(*responses.GetHit).ValueString()).To(Equal(setIfPresentValue))
-
-			// Verify the channels received data
-			compressedSize, ok = <-compressedDataChannel
-			Expect(ok).To(BeTrue())
-			Expect(compressedSize).To(BeNumerically(">", 0))
-			Expect(compressedSize).To(BeNumerically("<", originalSize))
-			decompressedSize, ok = <-decompressedDataChannel
-			Expect(ok).To(BeTrue())
-			Expect(decompressedSize).To(Equal(originalSize))
+			verifyCompressionFromChannels(compressedDataChannel, decompressedDataChannel, originalSize)
 		})
 
 		It("should successfully setWithHash and getWithHash", func() {
@@ -202,15 +188,7 @@ var _ = Describe("zstd-compression-middleware", Label("cache-service"), func() {
 			Expect(resp).To(BeAssignableToTypeOf(&responses.GetWithHashHit{}))
 			Expect(resp.(*responses.GetWithHashHit).ValueString()).To(Equal(value))
 			Expect(resp.(*responses.GetWithHashHit).HashByte()).To(Equal(hash))
-
-			// Verify the channels received data
-			compressedSize, ok := <-compressedDataChannel
-			Expect(ok).To(BeTrue())
-			Expect(compressedSize).To(BeNumerically(">", 0))
-			Expect(compressedSize).To(BeNumerically("<", originalSize))
-			decompressedSize, ok := <-decompressedDataChannel
-			Expect(ok).To(BeTrue())
-			Expect(decompressedSize).To(Equal(originalSize))
+			verifyCompressionFromChannels(compressedDataChannel, decompressedDataChannel, originalSize)
 		})
 
 		It("should successfully setIfHash and getWithHash", func() {
@@ -245,15 +223,7 @@ var _ = Describe("zstd-compression-middleware", Label("cache-service"), func() {
 			Expect(resp).To(BeAssignableToTypeOf(&responses.GetWithHashHit{}))
 			Expect(resp.(*responses.GetWithHashHit).ValueString()).To(Equal(setIfAbsentValue))
 			Expect(resp.(*responses.GetWithHashHit).HashByte()).To(Equal(hash))
-
-			// Verify the channels received data
-			compressedSize, ok := <-compressedDataChannel
-			Expect(ok).To(BeTrue())
-			Expect(compressedSize).To(BeNumerically(">", 0))
-			Expect(compressedSize).To(BeNumerically("<", originalSize))
-			decompressedSize, ok := <-decompressedDataChannel
-			Expect(ok).To(BeTrue())
-			Expect(decompressedSize).To(Equal(originalSize))
+			verifyCompressionFromChannels(compressedDataChannel, decompressedDataChannel, originalSize)
 
 			setIfPresentValue := getCompressableString()
 			originalSize = len(setIfPresentValue)
@@ -276,15 +246,7 @@ var _ = Describe("zstd-compression-middleware", Label("cache-service"), func() {
 			Expect(resp).To(BeAssignableToTypeOf(&responses.GetWithHashHit{}))
 			Expect(resp.(*responses.GetWithHashHit).ValueString()).To(Equal(setIfPresentValue))
 			Expect(resp.(*responses.GetWithHashHit).HashByte()).To(Equal(hash))
-
-			// Verify the channels received data
-			compressedSize, ok = <-compressedDataChannel
-			Expect(ok).To(BeTrue())
-			Expect(compressedSize).To(BeNumerically(">", 0))
-			Expect(compressedSize).To(BeNumerically("<", originalSize))
-			decompressedSize, ok = <-decompressedDataChannel
-			Expect(ok).To(BeTrue())
-			Expect(decompressedSize).To(Equal(originalSize))
+			verifyCompressionFromChannels(compressedDataChannel, decompressedDataChannel, originalSize)
 		})
 
 	})
@@ -348,15 +310,7 @@ var _ = Describe("zstd-compression-middleware", Label("cache-service"), func() {
 			Expect(getResp).To(BeAssignableToTypeOf(&responses.GetWithHashHit{}))
 			Expect(getResp.(*responses.GetWithHashHit).ValueString()).To(Equal(value))
 			Expect(getResp.(*responses.GetWithHashHit).HashByte()).To(Equal(hash))
-
-			// Verify the channels received data
-			compressedSize, ok := <-compressedDataChannel
-			Expect(ok).To(BeTrue())
-			Expect(compressedSize).To(BeNumerically(">", 0))
-			Expect(compressedSize).To(BeNumerically("<", originalSize))
-			decompressedSize, ok := <-decompressedDataChannel
-			Expect(ok).To(BeTrue())
-			Expect(decompressedSize).To(Equal(originalSize))
+			verifyCompressionFromChannels(compressedDataChannel, decompressedDataChannel, originalSize)
 		})
 
 		It("should not decompress when response was not compressed", func() {
@@ -440,15 +394,7 @@ var _ = Describe("zstd-compression-middleware", Label("cache-service"), func() {
 			jsonErr := json.Unmarshal(resp.(*responses.GetHit).ValueByte(), &retrievedUser)
 			Expect(jsonErr).To(BeNil())
 			Expect(retrievedUser).To(Equal(sampleUser))
-
-			// Verify the channels received data
-			compressedSize, ok := <-compressedDataChannel
-			Expect(ok).To(BeTrue())
-			Expect(compressedSize).To(BeNumerically(">", 0))
-			Expect(compressedSize).To(BeNumerically("<", originalSize))
-			decompressedSize, ok := <-decompressedDataChannel
-			Expect(ok).To(BeTrue())
-			Expect(decompressedSize).To(Equal(originalSize))
+			verifyCompressionFromChannels(compressedDataChannel, decompressedDataChannel, originalSize)
 		})
 	})
 })


### PR DESCRIPTION
Work towards https://github.com/momentohq/dev-eco-issue-tracker/issues/1223

Created a test-specific zstd middleware that uses channels to verify data is actually getting compressed and decompressed in tests.