### PR TITLE
chore: retire the machine-user release token

### DIFF
--- a/.github/workflows/on-push-to-main.yml
+++ b/.github/workflows/on-push-to-main.yml
@@ -11,10 +11,17 @@ jobs:
   readme:
     runs-on: ubuntu-24.04
     steps:
+      - name: Generate release bot token
+        id: app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ secrets.MOMENTO_RELEASE_APP_ID }}
+          private-key: ${{ secrets.MOMENTO_RELEASE_APP_PRIVATE_KEY }}
+
       - name: Setup repo
         uses: actions/checkout@v3
         with:
-          token: ${{ secrets.MOMENTO_MACHINE_USER_GITHUB_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: Generate README
         uses: momentohq/standards-and-practices/github-actions/generate-and-commit-oss-readme@gh-actions-v2
@@ -72,10 +79,17 @@ jobs:
     needs: [ test ]
     name: Release Please
     steps:
+      - name: Generate release bot token
+        id: app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ secrets.MOMENTO_RELEASE_APP_ID }}
+          private-key: ${{ secrets.MOMENTO_RELEASE_APP_PRIVATE_KEY }}
+
       - uses: google-github-actions/release-please-action@v3
         id: release
         with:
-          token: ${{ secrets.MOMENTO_MACHINE_USER_GITHUB_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
           release-type: go
           package-name: momento-compression-zstd
           default-branch: main


### PR DESCRIPTION
Retires this repo's use of the `MOMENTO_MACHINE_USER_GITHUB_TOKEN` org secret, a
classic PAT on a shared machine user that had to be renewed by hand every 90 days.

- Work that creates a ref, opens a PR, or reaches another repo now mints a
  short-lived installation token from the `momento-release-bot` GitHub App.
  A push or PR authored by the built-in `GITHUB_TOKEN` deliberately does not
  start a workflow run, so release automation needs an app token to keep CI firing.

`MOMENTO_RELEASE_APP_ID` and `MOMENTO_RELEASE_APP_PRIVATE_KEY` are already
provisioned org-wide, so there is no per-repo setup.
